### PR TITLE
fix: correct architecture diagram in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ graph TD
 
     dev -->|"push"| homelab_repo
     dev -->|"push"| docker_repo
-    docker_repo -->|"CI builds"| ghcr
-    ghcr -->|"pulled by"| tooling
+    docker_repo -->|"CI builds & pushes"| ghcr
+    docker_repo -->|"local build"| tooling
+    ghcr -->|"used by CI"| homelab_repo
     age -->|"decrypt secrets"| tooling
     kubeconfig -->|"cluster access"| tooling
     tooling -->|"tofu apply"| vps


### PR DESCRIPTION
## Summary

- Remove incorrect `ghcr --> tooling` arrow (the local tooling container is built from the Dockerfile, not pulled from GHCR)
- Add `docker_repo --> tooling` to reflect the actual local build flow
- Add `ghcr --> homelab_repo` to show that GHCR is consumed by Homelab's CI (changelog job)

## Test plan

- [ ] Verify the Mermaid diagram renders correctly on the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)