### PR TITLE
ci: migrate changelog to app bot, add Protected env, CODEOWNERS, PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @VictorMalodPortfolio

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What does this PR do?
+
+<!-- Describe the change and why it is needed. -->
+
+## Type of change
+
+- [ ] Infrastructure change (OpenTofu / OVH)
+- [ ] Kubernetes / ArgoCD / Helm change
+- [ ] CI / workflow change
+- [ ] Bug fix
+- [ ] Documentation
+
+## Checklist
+
+- [ ] Commit messages follow the conventional commits format
+- [ ] The Trivy IaC scan passes (or findings are reviewed and accepted)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+    paths-ignore:
+      - 'CHANGELOG.md'
 
 jobs:
   conventional-commits:
@@ -72,9 +74,11 @@ jobs:
   changelog:
     name: Update CHANGELOG
     runs-on: ubuntu-latest
+    needs: trivy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: Protected
     permissions:
-      contents: write
+      contents: read
       packages: read
     container:
       image: ghcr.io/victormalodportfolio/k8s-tooling:latest
@@ -83,9 +87,17 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.LAB_BOT_ID }}
+          private-key: ${{ secrets.LAB_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Fix git ownership
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -93,10 +105,11 @@ jobs:
       - name: Generate CHANGELOG
         run: git-cliff --output CHANGELOG.md
 
-      - name: Commit CHANGELOG
+      - name: Commit and push
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet CHANGELOG.md && echo "No changes, skipping." && exit 0
+          git config user.name "Homelab Portfolio Bot[bot]"
+          git config user.email "homelab-portfolio-bot[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "docs: update CHANGELOG"
+          git commit -m "docs: update CHANGELOG"
           git push


### PR DESCRIPTION
## What does this PR do?

Brings Homelab CI in line with DockerTooling:

- **changelog job**: uses Homelab Portfolio Bot via app token (`vars.LAB_BOT_ID` / `secrets.LAB_BOT_PRIVATE_KEY`) instead of `github-actions[bot]`, so it can bypass branch protection
- **Protected environment**: bot credentials are gated behind the `Protected` environment — must be created in repo settings before merging
- **`[skip ci]`**: changelog commits no longer trigger a new CI run
- **`needs: trivy`**: changelog only runs after the IaC scan passes
- **CODEOWNERS**: requires a review from `@VictorMalodPortfolio` to merge
- **PR template**: standard checklist for infra/k8s/CI changes

## Type of change

- [x] CI / workflow change

## Checklist

- [x] Commit messages follow the conventional commits format
- [x] The Trivy IaC scan passes (or findings are reviewed and accepted)

> **Before merging**: create a `Protected` environment in repo Settings → Environments, add `LAB_BOT_ID` (variable) and `LAB_BOT_PRIVATE_KEY` (secret), and add Homelab Portfolio Bot to the branch protection bypass list.