### PR TITLE
fix: prevent argocd-cm from being pruned during sync

### DIFF
--- a/helm/argocd-config/templates/argocd-cm.yaml
+++ b/helm/argocd-config/templates/argocd-cm.yaml
@@ -3,5 +3,7 @@ kind: ConfigMap
 metadata:
   name: argocd-cm
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 data:
   helm.valuesFileSchemes: secrets, https


### PR DESCRIPTION
## Summary
- Add `Prune=false` sync-option annotation to `argocd-cm` ConfigMap
- Prevents ArgoCD from deleting its own critical configuration during sync failures
- Breaks the circular dependency where ArgoCD needs `argocd-cm` to function but also manages it via the `argocd-config` app

## Context
After merging #14, ArgoCD lost its `argocd-cm` ConfigMap during a sync issue, which made all applications show `Unknown` status and the UI unresponsive. Because `argocd-cm` was managed by `argocd-config` (which itself couldn't sync without a working ArgoCD), the cluster entered an unrecoverable state requiring manual intervention.

## Test plan
- [ ] Verify `argocd-config` syncs successfully with the annotation
- [ ] Confirm `argocd-cm` shows `Prune=false` in ArgoCD sync details

🤖 Generated with [Claude Code](https://claude.com/claude-code)