### PR TITLE
feat: configure ArgoCD OIDC with Authelia

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
           output: trivy-results.sarif
           exit-code: '0'
           severity: CRITICAL,HIGH
+          trivyignores: .trivyignore.yaml
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v4
@@ -170,6 +171,7 @@ jobs:
           format: table
           exit-code: '1'
           severity: CRITICAL,HIGH
+          trivyignores: .trivyignore.yaml
 
   changelog:
     name: Update CHANGELOG

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -68,3 +68,8 @@ vulnerabilities:
   # Found in: ArgoCD base image (multiple binaries)
   - id: CVE-2026-32282
     statement: Upstream ArgoCD issue — no fixed ArgoCD release available yet.
+
+misconfigurations:
+  # argocd-cm contains a $secret-name:key reference, not an actual secret
+  - id: KSV-0109
+    statement: The clientSecret value in argocd-cm is a reference ($argocd-oidc-secret:key), not a plaintext secret.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitOps](https://img.shields.io/badge/GitOps-ArgoCD-EF7B4D?logo=argo&logoColor=white&style=for-the-badge)](https://argo-cd.readthedocs.io)
 [![IaC](https://img.shields.io/badge/IaC-OpenTofu-623CE4?logo=opentofu&logoColor=white&style=for-the-badge)](https://opentofu.org)
 [![TLS](https://img.shields.io/badge/TLS-Let's%20Encrypt-003A70?logo=letsencrypt&logoColor=white&style=for-the-badge)](https://letsencrypt.org)
+[![Auth](https://img.shields.io/badge/Auth-Authelia%20MFA-1A1F6C?logo=authelia&logoColor=white&style=for-the-badge)](https://www.authelia.com)
 [![Trivy](https://img.shields.io/badge/Trivy-IaC%20scan-1904DA?logo=aquasecurity&logoColor=white&style=for-the-badge)](https://github.com/VictorMalodPortfolio/Homelab/security/code-scanning)
 [![Renovate](https://img.shields.io/badge/Renovate-enabled-1A1F6C?logo=renovatebot&logoColor=white&style=for-the-badge)](https://github.com/renovatebot/renovate)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-FE5196?logo=conventionalcommits&logoColor=white&style=for-the-badge)](https://conventionalcommits.org)
@@ -40,6 +41,7 @@ graph TD
             cert_manager["cert-manager\n+ OVH webhook"]
             traefik["Traefik\n(ingress)"]
             tls_secret["Wildcard TLS cert"]
+            authelia["Authelia\n(OIDC + ForwardAuth)"]
         end
     end
 
@@ -59,11 +61,14 @@ graph TD
     argocd -->|"decrypts secrets"| helm_secrets
     argocd -->|"deploys"| cert_manager
     argocd -->|"deploys"| traefik
+    argocd -->|"deploys"| authelia
     cert_manager -->|"DNS-01 via OVH API"| dns
     acme -->|"verifies TXT"| dns
     acme -->|"issues cert"| cert_manager
     cert_manager -->|"stores"| tls_secret
     traefik -->|"serves TLS"| tls_secret
+    authelia -->|"OIDC SSO"| argocd
+    traefik -->|"ForwardAuth"| authelia
 ```
 
 ## Repository structure
@@ -75,7 +80,9 @@ Homelab/
 ├── terraform/            # OpenTofu — OVH VPS, DNS, k3s provisioning
 ├── argocd/               # ArgoCD Application manifests (App of Apps)
 ├── helm/                 # Helm charts and values per app
-│   ├── argocd-config/    # ArgoCD server config (insecure mode, helm-secrets, IngressRoute)
+│   ├── argocd-config/    # ArgoCD server config (OIDC, RBAC, helm-secrets, IngressRoute)
+│   ├── authelia/         # Authelia config + SOPS-encrypted secrets (OIDC, session, storage)
+│   ├── authelia-users/   # Authelia users database (SOPS-encrypted)
 │   ├── cert-manager/
 │   ├── cert-manager-webhook-ovh/
 │   ├── cluster-issuers/

--- a/argocd/argocd-config.yaml
+++ b/argocd/argocd-config.yaml
@@ -9,6 +9,9 @@ spec:
     repoURL: git@github.com:VictorMalodPortfolio/Homelab.git
     targetRevision: main
     path: helm/argocd-config
+    helm:
+      valueFiles:
+        - secrets://secrets.sops.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/helm/argocd-config/secrets.sops.yaml
+++ b/helm/argocd-config/secrets.sops.yaml
@@ -1,0 +1,16 @@
+oidcClientSecret: ENC[AES256_GCM,data:tw2jPHW3gLoytHUk/yDfL9WzLZXoryuTfR+ceDBm/82VX9CPkD0ABSvUgEnMqPQUR2KDpT4Cq/noocQhtShOzA==,iv:Hq1Bb7t/rKIwc7uClAF2ksjczCVFQ57iHZDfjtKQkbI=,tag:E07xf4lP1vf1fByJkRihkg==,type:str]
+sops:
+    age:
+        - recipient: age184fnlwvmqnepnjwtxptquyf62ejasynvfujs0tgpts7vzavj5glqmmn23e
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6bEtlcmdUNTRFeDhQaDJD
+            ZlV1cVkwWkFXcnl0NW1wSG9PNjlhNzhNYXpjCm9EWHV1S3I2Nmw2T0RacFdMc05p
+            MHpLL0JkS3hGRm5OUFhyWFNMb0dXYkUKLS0tIEVqU1lWM2FxaG9wVU96OUxuREgy
+            NVNPdDZyaXpVV1o3ZEtwTnkzM2ZwaEEK/oTX2wQPpEY/QIv9rJDwKVIfLFQjM97t
+            GTyK+bAal6wt6x3Nzb4hHSAEOAGYzj8z7BGokDgsRj9vN7wtKxhyvQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-13T22:11:57Z"
+    mac: ENC[AES256_GCM,data:8JNHoUqe2xiImsuKVZrh9Y+5ANPRNqe7UygJ1U8CmkXzU3/E+bxTbnyQ1ABhsJbAV/33jihc3iTDUAtsxgUJqSK1YKo+Sen9DX9HFpEiGtEaXSdB0Z/6EJZcjtDAaoD0Xx5yhG/JdWjssNUPdQE1Dn/DtprMe8uZNAd8wjnNQgo=,iv:SY6vBenWglESKDpvial3WGXXogNmJaJxoR5/vTpqyBA=,tag:OgwZXvpV7J6G3MFW8tr0iQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/helm/argocd-config/templates/argocd-cm.yaml
+++ b/helm/argocd-config/templates/argocd-cm.yaml
@@ -9,3 +9,17 @@ metadata:
     argocd.argoproj.io/sync-options: Prune=false
 data:
   helm.valuesFileSchemes: secrets, https
+  url: https://{{ .Values.host }}
+  oidc.config: |
+    name: Authelia
+    issuer: https://auth.victor-malod.ovh
+    clientID: argocd
+    clientSecret: $argocd-oidc-secret:oidc.authelia.clientSecret
+    requestedScopes:
+      - openid
+      - groups
+      - email
+      - profile
+    requestedIDTokenClaims:
+      groups:
+        essential: true

--- a/helm/argocd-config/templates/argocd-rbac-cm.yaml
+++ b/helm/argocd-config/templates/argocd-rbac-cm.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+data:
+  policy.csv: |
+    g, admins, role:admin
+    p, role:dev, applications, get, *, allow
+    p, role:dev, applications, sync, *, allow
+    p, role:dev, logs, get, *, allow
+    g, dev, role:dev
+  policy.default: role:readonly

--- a/helm/argocd-config/templates/argocd-secret.yaml
+++ b/helm/argocd-config/templates/argocd-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-oidc-secret
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+type: Opaque
+stringData:
+  oidc.authelia.clientSecret: {{ .Values.oidcClientSecret | quote }}

--- a/helm/authelia-users/secrets.sops.yaml
+++ b/helm/authelia-users/secrets.sops.yaml
@@ -1,4 +1,4 @@
-usersDatabase: ENC[AES256_GCM,data:/kDXoG00YG6phgaFYiczBpfUbmXVg6MRcx7Uo29r72v9StfiiQmbOtDNevD8Avy11dRfyKpgvQSSQuiFq345Q3tK3oXEYHOuidDwxm1+4YgIxqLkhL/Um92GGmw8eHu2WcEqlwxtMElTEfCUoX7kuRWVdN8eNg4LSDK43NX+R8o6idUsxJB/WEdhXyVY5nUx25MJT3gH295d8QUxnx/SSJ6NSPpnpKzl4uXppa9+gYKp0LcMiJD8pliYYOB3QTt5TVxacDYBGd/CeX1VULfB3A1OtnGIeFe0vfF+VMRgoYN4k+il7Pq9DRS/hTjVjOG0IO+DjjfTRrwC9Wsxrh1woV6TjZbwfYu2P4gPeMf3UpBr3V4O8PZScqgM2aZqWw7s3gZ58fKgyljN1HUPqtjIh9/lU7i8+4SPH1J2p40cKfzt1RE=,iv:xDgJV+NnneR7h2Llbe1x0lysf0TT57XeWDysDfzsNzY=,tag:k95EV19Ca6CaQcObF5cDUQ==,type:str]
+usersDatabase: ENC[AES256_GCM,data:MevH28bdge94H1bhMrqreCYfphWh/IU2hdSFq3mzpT8RjeaQIxfWFTK0yw8J4LnZs1qR4jSjYpvhMsB0/Y/J6PlJQrop2FXjwLaqGy7QHS4Bk1TQzzcAo7f5Ef90oK7pu/TtRO+/Y055BlmNd1MD2F/8fpJZsSjRFeBNsqD1AKjA2RrKavHyr7oMPWqnvVP50lzpKTb1V6Qgewb14KgE1+Bwqicc4s3xQLGe9u9vUogs7emwZod9cEd+xuQeZgFHVM7KEfjfqe42ZM6s/6RCCMRFBHm2dT7h8ibTtJ6NAJx9pHNWgnzTlZcNmOn3KBKbNE/dOkvMB7CsS61uuNg/dLG11Csl0r1izhHffDjyOPX7V8HIjVoQar3zrp8K5PKf64MjvkPbu4r9WmCETuEnN4egsrKoYxz4gqWA58TGNIDbC+s=,iv:viHz1fW1lHq8FztfPC1r6LyHzWEaZTCiE5VHjSvrboQ=,tag:96sVP/3AX6iaKi45yLqmKw==,type:str]
 sops:
     age:
         - recipient: age184fnlwvmqnepnjwtxptquyf62ejasynvfujs0tgpts7vzavj5glqmmn23e
@@ -10,7 +10,7 @@ sops:
             cE5TemxjaVVBOVdBSnBEQy9tRXhINFkKT927G3yCNhFU+1NJm7iP3d2j7iw4cSTs
             /bB2USXugq4inJ/WFZ/FwjUj8JOI2XLc7HOm9y0IRZqhCQXHvuttgA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-13T20:29:31Z"
-    mac: ENC[AES256_GCM,data:7EQOrISMJ+uCKzJz5HufXh7WHu3czGWmQGEKM+URi/8gizSgxP1SmpvxjXvQe+jkz1QSSc3kRyDhxMxcdITKmwOcvQ+oJXWqeQNybpAJL3BHkI+NxzO4CYDq8vmIHgT5nNPJmfIBBzzKtICYSGesRQsZDK0ifUHrkGG11K63pAk=,iv:1+wRl23xHNvoKt6qsGD+qFED/PYmyVjymCcaw7QdD+Q=,tag:sAAsOnqeUMufJAKp1WCXFQ==,type:str]
+    lastmodified: "2026-04-13T21:56:44Z"
+    mac: ENC[AES256_GCM,data:9GMMZl2CjQ7Y6XjV+y6JmQ1Pzvyv0tos1nfzqQ/h/4rdfgvO3rPaWg+9gMKsAQiTbX7otzaMS3dJcPSbDss4OiDJS08V4JvLOrdheeHhZBp9nQDtYIw7URAMsFnVczdjHExtooauU6TbSIflbChxLl4n0YBZ5sl5GGjWH+WEdDU=,iv:Qt7JjEG9jj1bZrYQPD1pZg8k4d7kEV64XQb1bTNpxCc=,tag:4k0/a/n8y7Vz6WSoc16jSA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/helm/authelia/secrets.sops.yaml
+++ b/helm/authelia/secrets.sops.yaml
@@ -18,7 +18,7 @@ configMap:
             clients:
                 - client_id: ENC[AES256_GCM,data:dIvaIUkT,iv:caNffP/EE34VWY/8Q+BeIeG9sPGO3MEjCgE0q28/Prc=,tag:ur323eSqiwYAF6/wE7fDkg==,type:str]
                   client_name: ENC[AES256_GCM,data:3N3VY18y,iv:iIvOQXixEErfX9f1Qdc2GWUlxZrhhXddfMhWMvQCCVQ=,tag:lMJUSwSC4ParYkRzNGT3VQ==,type:str]
-                  client_secret: ENC[AES256_GCM,data:TvKqGO6yQGs+gkvQtish7/qCzcqTicj0+sfTbQVVEZOaz2SsZexfNn7xMACwCiCMKPwDv8wsY60QOuMCJTG/98KMK/5x5PIaCbiG6IKI8N7sMA/lxx5UxDOQlj17zH39DQ==,iv:Le0zMJnuowdWrMqK1zYtJqorT6gIHZhbywFmPMlQfUM=,tag:2VR/qu66D/RJWKymmdtX7g==,type:str]
+                  client_secret: ENC[AES256_GCM,data:uOXm+C1VP3qy90WO8ALo6II3M0U2LNC3D4YTRF5yMEtGWgVlhhKBQvVofzzz4oXKvqeplmjDY37pGGXALTe2esJZxwJ9m/jUXEyNVvTBGDqcXb2f18H53wXEoHNBF/Jc5Q==,iv:ENMRcc6UBTBcu8PAe2NyS80u+NWsm7zuu9U41+HmFz0=,tag:03KzgeDVoLhJHPnSSsoKEg==,type:str]
                   authorization_policy: ENC[AES256_GCM,data:hZ2uIQy9dqVanw==,iv:QadapYsomULRde9xXL2gGbznnMRtNvMRe6acUpPjSTU=,tag:SyF+OCb2j6f+wt3ow75w8g==,type:str]
                   redirect_uris:
                     - ENC[AES256_GCM,data:aZpvjLa2lhByH4g6dTZgx1D85axuEBgE5gqvRHwISRLjbhNWA/3dTO0/+1gg,iv:NvFxUfiH133U/fTFFitjtss6dHFZqSUTD5HfPIHv+lA=,tag:zbao1J4d340pZUAVnicAwg==,type:str]
@@ -38,7 +38,7 @@ sops:
             dGY2Sm5aRDZSUkFEeStkcURmdjFOclkKAqXwo9WktfDfAiVYxZ2gi+/vM06BWDlD
             rLKUzd6076oQNrYEUxlbBROlRBSDpQUU0d9cuWKKlagVmHjUm860aA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-13T20:29:32Z"
-    mac: ENC[AES256_GCM,data:Mk1ba97k6DdfQbFJGWe+S4btE6dG9B2QCGrmcctLV28x8+OX1/h2o4iVAvp9fXqZZSn6nCAf23mHlxYwsI4+OW2SSuLwK8A4bMrFlABYQSV/s8iWG6ILuj7SGQKoWAeVnwogVJ3ZVoIjr6Pr5avk5PTDtSRZT0mfCL5bOJf38bo=,iv:wUYtYxP3sQb8gn97wz6IQ5oupsJvPVSQqmH9aH1FsH8=,tag:ZoI2qQ7RcTGaP6y8hzDAjQ==,type:str]
+    lastmodified: "2026-04-13T22:10:40Z"
+    mac: ENC[AES256_GCM,data:rIOizsNzn0F/chbB4N0An2UQwMkzMKdIcsatcpUgM1X5pVB2TK8caocCm6MfLih/CPSIGAHxif055BmLbqmD0JdqrNykHOUkqb9TN2VfUy8aVAA8bL/+UkdVtDVdmAbxYTcGAx3AQ0bmHq+SpOJj6R9hFcjcUeXYP5jDrCdOJg8=,iv:biK8gxZ/iW/2tKgt9O5VlY8plkdMnHFXo9+Of8xLBqU=,tag:avF+lc6Fg1YvqUQthXyadw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
- Configure ArgoCD to use Authelia as OIDC provider for SSO with MFA
- RBAC: `admins` group → admin role, `dev` group → read + sync + logs
- OIDC client secret stored in separate `argocd-oidc-secret` (SOPS-encrypted, referenced via `$argocd-oidc-secret:key` syntax)
- Regenerated OIDC client secret pair (argon2id hash for Authelia, raw for ArgoCD)
- Updated users database password

## Test plan
- [ ] ArgoCD shows "Log in via Authelia" button on login page
- [ ] Login redirects to Authelia, completes MFA, returns to ArgoCD
- [ ] User sees admin permissions (admins group)
- [ ] Disable admin user after confirming OIDC works

🤖 Generated with [Claude Code](https://claude.com/claude-code)